### PR TITLE
chore: Bump Dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,11 +7,11 @@ plugins {
 	id 'maven-publish'
 
 	id "com.diffplug.spotless" version "6.22.0"
-	id 'com.github.johnrengelman.shadow' version '8.1.1'
+	id 'com.gradleup.shadow' version '8.3.6'
 }
 
 group = 'io.qdrant'
-version = '1.2.2'
+version = '1.2.3'
 description = 'Kafka Sink Connector for Qdrant.'
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 java.targetCompatibility = JavaVersion.VERSION_1_8
@@ -47,7 +47,7 @@ dependencies {
 	implementation 'io.grpc:grpc-protobuf:1.59.0'
 	implementation "io.grpc:grpc-netty-shaded:1.59.0"
 	implementation 'com.google.guava:guava:33.2.1-jre'
-	implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.4'
 	implementation 'com.google.protobuf:protobuf-java-util:3.25.3'
 	implementation 'org.slf4j:slf4j-api:2.0.13'
 


### PR DESCRIPTION
[{Java [{CVE-2025-52999 com.fasterxml.jackson.core:jackson-core 2.14.2 2.15.0 com.fasterxml.jackson.core/jackson-core: jackson-core Potential StackoverflowError jackson-core contains core low-level incremental ("streaming") parser and generator abstractions used by Jackson Data Processor. In versions prior to 2.15.0, if a user parses an input file and it has deeply nested data, Jackson could end up throwing a StackoverflowError if the depth is particularly large. jackson-core 2.15.0 contains a configurable limit for how deep Jackson will traverse in an input document, defaulting to an allowable depth of 1000. jackson-core will throw a StreamConstraintsException if the limit is reached. jackson-databind also benefits from this change because it uses jackson-core to parse JSON inputs. As a workaround, users should avoid parsing input files from untrusted sources. HIGH [https://access.redhat.com/errata/RHSA-2025:12280 https://access.redhat.com/security/cve/CVE-2025-52999 https://bugzilla.redhat.com/2374804 https://errata.almalinux.org/9/ALSA-2025-12280.html https://github.com/FasterXML/jackson-core https://github.com/FasterXML/jackson-core/pull/943 https://github.com/FasterXML/jackson-core/security/advisories/GHSA-h46c-h94j-95f3 https://linux.oracle.com/cve/CVE-2025-52999.html https://linux.oracle.com/errata/ELSA-2025-14126.html https://nvd.nist.gov/vuln/detail/CVE-2025-52999 [https://www.cve.org/CVERecord?id=CVE-2025-52999]}]](https://www.cve.org/CVERecord?id=CVE-2025-52999]%7D])}]