### PR TITLE
ci: update third-party actions to Node 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Gradle Build
-        uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
         with:
           gradle-version: 8.5
           arguments: build


### PR DESCRIPTION
gradle/gradle-build-action v2.12.0 (node16) -> v3.5.0 (composite). June 2 deadline.