### PR TITLE
chore: Bump lz4-java to 1.11.1 to fix CVE-2026-59949

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = 'io.qdrant'
-version = '1.4.0'
+version = '1.4.1'
 description = 'Kafka Sink Connector for Qdrant.'
 java.sourceCompatibility = JavaVersion.VERSION_17
 java.targetCompatibility = JavaVersion.VERSION_17

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ def kafkaVersion = '4.3.1'
 dependencies {
 	implementation "org.apache.kafka:connect-api:$kafkaVersion"
 	implementation 'io.qdrant:client:1.18.3'
+	// lz4-java:1.11.1 fixes CVE-2026-59949.
+	implementation 'at.yawk.lz4:lz4-java:1.11.1'
 	implementation 'io.grpc:grpc-protobuf:1.82.2'
 	implementation "io.grpc:grpc-netty-shaded:1.82.2"
 	implementation 'com.google.guava:guava:33.6.0-jre'

--- a/src/main/java/io/qdrant/kafka/QdrantSinkConnector.java
+++ b/src/main/java/io/qdrant/kafka/QdrantSinkConnector.java
@@ -40,6 +40,6 @@ public class QdrantSinkConnector extends SinkConnector {
 
   @Override
   public String version() {
-    return "1.4.0";
+    return "1.4.1";
   }
 }

--- a/src/main/java/io/qdrant/kafka/QdrantSinkTask.java
+++ b/src/main/java/io/qdrant/kafka/QdrantSinkTask.java
@@ -22,7 +22,7 @@ public class QdrantSinkTask extends SinkTask {
 
   @Override
   public String version() {
-    return "1.4.0";
+    return "1.4.1";
   }
 
   @Override


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-xx22-p4ch-683r